### PR TITLE
Add PHP lint workflow

### DIFF
--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -1,0 +1,16 @@
+name: PHP Lint
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: PHP Syntax Check
+        run: |
+          php -l video-link-generator.php
+          php -l video-link-generator/video-link-generator.php


### PR DESCRIPTION
## Summary
- add `.github/workflows/php-lint.yml` to check PHP syntax on `push` and `pull_request`

## Testing
- `php -l video-link-generator.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854924e1c6083249ef47c652e82b9e4