### PR TITLE
Fix constant redeclaration

### DIFF
--- a/video-link-generator.php
+++ b/video-link-generator.php
@@ -10,7 +10,9 @@ License: GPL2
 
 defined('ABSPATH') or die('No script kiddies please!');
 
-define('VLG_FREE_ACTIVE', true);
+if (!defined('VLG_FREE_ACTIVE')) {
+    define('VLG_FREE_ACTIVE', true);
+}
 
 add_action('admin_menu', function() {
     add_options_page('Video Link Generator', 'Video Link Generator', 'manage_options', 'video-link-generator', function() {

--- a/video-link-generator/video-link-generator.php
+++ b/video-link-generator/video-link-generator.php
@@ -10,7 +10,9 @@ License: GPL2
 
 defined('ABSPATH') or die('No script kiddies please!');
 
-define('VLG_FREE_ACTIVE', true);
+if (!defined('VLG_FREE_ACTIVE')) {
+    define('VLG_FREE_ACTIVE', true);
+}
 
 add_action('admin_menu', function() {
     add_options_page('Video Link Generator', 'Video Link Generator', 'manage_options', 'video-link-generator', function() {


### PR DESCRIPTION
## Summary
- prevent redeclaring `VLG_FREE_ACTIVE` constant in main plugin files

## Testing
- `php -l video-link-generator.php` *(fails: `php` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548fc879b08324b44bdc86b7e8ef35